### PR TITLE
#57 Support operation on ES only

### DIFF
--- a/vectortile-server/es-only-application.yml
+++ b/vectortile-server/es-only-application.yml
@@ -1,0 +1,42 @@
+#
+# Sample configuration for running the server to only expose the ES-backed maps
+# The ES hosts are likely all that needs to be changed
+#
+
+esConfiguration:
+  elasticsearch:
+    # The sniffer requires >1 nodes to be configured
+    hosts: http://es1.myserver.com:9200,http://es2.myserver.com:9200
+    index: occurrence
+  sniffInterval: 100
+  tileSize: 1024
+  bufferSize: 64
+
+# The server configuration
+server:
+  servlet:
+    context-path: /map/
+  compression:
+    enabled: true
+    min-response-size: 1
+    mime-types: application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,image/jpeg,application/x-protobuf,application/gzip
+    excluded-user-agents:
+spring:
+  application.name: vectortile-server
+  resources:
+    static-locations: classpath:/static/
+  liquibase:
+    enabled: false
+  mvc:
+    static-path-pattern: /debug/**
+  # This disables the zookeeper service registration
+  cloud:
+    zookeeper:
+      enabled: false
+      discovery:
+        enabled: false
+  # Important! This profile disables the resources that bring in the HBase dependencies
+  profiles.include: es-only
+
+management:
+  endpoints.web.exposure.include: "*"

--- a/vectortile-server/src/main/java/org/gbif/maps/TileServerApplication.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/TileServerApplication.java
@@ -58,7 +58,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
     "org.gbif.ws.server.mapper"
   },
   exclude = {
-    RabbitAutoConfiguration.class,
+    RabbitAutoConfiguration.class
   })
 @EnableConfigurationProperties
 public class TileServerApplication {
@@ -152,7 +152,7 @@ public class TileServerApplication {
     HBaseMaps hBaseMaps(TileServerConfiguration tileServerConfiguration) throws Exception {
       if (tileServerConfiguration.getHbase()==null) {
         System.out.println("No HBase configuration is provided (Hint: if errors occur, perhaps you miss setting the 'es-only' profile in Spring?)");
-        return null; // skip HBase when no config is required
+        return null; // skip HBase when no config is available
 
       } else {
         // Either use Zookeeper or static config to locate tables

--- a/vectortile-server/src/main/java/org/gbif/maps/resource/BackwardCompatibility.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/resource/BackwardCompatibility.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -43,6 +44,7 @@ import static org.gbif.maps.resource.TileResource.*;
 @RequestMapping(
   value = "density"
 )
+@Profile("!es-only")
 public class BackwardCompatibility {
 
   private static final Logger LOG = LoggerFactory.getLogger(BackwardCompatibility.class);

--- a/vectortile-server/src/main/java/org/gbif/maps/resource/RegressionResource.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/resource/RegressionResource.java
@@ -41,6 +41,7 @@ import org.elasticsearch.search.aggregations.bucket.terms.Terms;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -74,6 +75,7 @@ import static org.gbif.maps.resource.Params.mapKeys;
 @RequestMapping(
   value = "/occurrence/regression"
 )
+@Profile("!es-only")
 public final class RegressionResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(RegressionResource.class);

--- a/vectortile-server/src/main/java/org/gbif/maps/resource/TileResource.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/resource/TileResource.java
@@ -38,6 +38,7 @@ import javax.validation.constraints.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -70,6 +71,7 @@ import static org.gbif.maps.resource.Params.toMinMaxYear;
 @RequestMapping(
   value = "/occurrence/density"
 )
+@Profile("!es-only")
 public final class TileResource {
 
   private static final Logger LOG = LoggerFactory.getLogger(TileResource.class);


### PR DESCRIPTION
This change should allow a user to run the server on ES-only, ignoring HBase maps, but _not_ affect the GBIF system.
I have confirmed this works for ES-only mode, but can you please pay attention in review that this won't break GBIF?