### PR TITLE
New style for thumbnail usage

### DIFF
--- a/mapnik-server/src/main/node/cartocss/scaled-circles-thumbnail-black.mss
+++ b/mapnik-server/src/main/node/cartocss/scaled-circles-thumbnail-black.mss
@@ -1,0 +1,11 @@
+#occurrence {
+  marker-line-width: 0;
+  marker-allow-overlap: true;
+  marker-fill: #000000;
+
+                 [total <=    10] { marker-width: 25;  marker-fill: #000; marker-opacity: 1.0; marker-line-color: #000; marker-line-width: 1 }
+  [total >    10][total <=   100] { marker-width: 28;  marker-fill: #000; marker-opacity: 0.8; marker-line-color: #000; marker-line-width: 0 }
+  [total >   100][total <=  1000] { marker-width: 30;  marker-fill: #000; marker-opacity: 0.7; marker-line-color: #000; marker-line-width: 0 }
+  [total >  1000][total <= 10000] { marker-width: 32;  marker-fill: #000; marker-opacity: 0.6; marker-line-color: #000; marker-line-width: 0 }
+  [total > 10000]                 { marker-width: 35;  marker-fill: #000; marker-opacity: 0.6; marker-line-color: #000; marker-line-width: 0 }
+}

--- a/mapnik-server/src/main/node/cartocss/scaled-circles-thumbnail.mss
+++ b/mapnik-server/src/main/node/cartocss/scaled-circles-thumbnail.mss
@@ -1,0 +1,11 @@
+#occurrence {
+  marker-line-width: 0;
+  marker-allow-overlap: true;
+  marker-fill: #206EFF;
+
+                 [total <=    10] { marker-width: 25;  marker-fill: #fed976; marker-opacity: 1.0; marker-line-color: #fe9724; marker-line-width: 1 }
+  [total >    10][total <=   100] { marker-width: 28;  marker-fill: #fd8d3c; marker-opacity: 0.8; marker-line-color: #fd5b24; marker-line-width: 0 }
+  [total >   100][total <=  1000] { marker-width: 30;  marker-fill: #fd8d3c; marker-opacity: 0.7; marker-line-color: #fd471d; marker-line-width: 0 }
+  [total >  1000][total <= 10000] { marker-width: 32;  marker-fill: #f03b20; marker-opacity: 0.6; marker-line-color: #f01129; marker-line-width: 0 }
+  [total > 10000]                 { marker-width: 35;  marker-fill: #bd0026; marker-opacity: 0.6; marker-line-color: #bd0047; marker-line-width: 0 }
+}

--- a/mapnik-server/src/main/node/styles.js
+++ b/mapnik-server/src/main/node/styles.js
@@ -44,6 +44,10 @@ namedStyles["orange.marker"] = compileStylesheetSync("./cartocss/orange-marker.m
 // Adhoc map style for ES portal (mode=GEO_CENTROID)
 namedStyles["scaled.circles"] = compileStylesheetSync("./cartocss/scaled-circles.mss");
 
+// Adhoc map style for thumbnails (mode=GEO_CENTROID)
+namedStyles["scaled.circles.thumbnail"] = compileStylesheetSync("./cartocss/scaled-circles-thumbnail.mss");
+namedStyles["scaled.circles.thumbnail.black"] = compileStylesheetSync("./cartocss/scaled-circles-thumbnail-black.mss");
+
 
 // Miscellaneous styles
 namedStyles["green2.poly"] = compileStylesheetSync("./cartocss/green2-poly.mss");


### PR DESCRIPTION
Our current styles have fairly small points. Which is fine for normal maps. But I would like to be able to use our tiles for thumbnail like usages. The problem is that queries without much data disappear.

<img width="294" alt="Screenshot 2022-10-05 at 12 51 36" src="https://user-images.githubusercontent.com/6759267/194045416-e8b20b13-f010-4cb4-b80f-6a8b33b31a5e.png">

I've tried to add 2 new styles, both have larger dots that our current. One of them only serves black circles. The point of the latter is to use browser image filters to style them. That part is simply an experiment at this point.