### PR TITLE
#111 Remove tile cache

### DIFF
--- a/vectortile-server/src/main/java/org/gbif/maps/CacheConfiguration.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/CacheConfiguration.java
@@ -45,13 +45,6 @@ public class CacheConfiguration {
     return new Cache2kConfig<>();
   }
 
-  @ConfigurationProperties(prefix = "cache.tiles")
-  @Bean
-  public Cache2kConfig<HBaseMaps.TileKey, Optional<byte[]>> tileCache2kConfig() {
-    return new Cache2kConfig<>();
-  }
-
-
   @ConfigurationProperties(prefix = "cache.points")
   @Bean
   public  Cache2kConfig<String, Optional<PointFeature.PointFeatures>> pointsCache2kConfig() {

--- a/vectortile-server/src/main/java/org/gbif/maps/TileServerApplication.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/TileServerApplication.java
@@ -228,8 +228,7 @@ public class TileServerApplication {
     @Bean
     @Profile("!es-only")
     HBaseMaps hBaseMaps(TileServerConfiguration tileServerConfiguration, SpringCache2kCacheManager cacheManager, MeterRegistry meterRegistry,
-                        Cache2kConfig<String, Optional<PointFeature.PointFeatures>> pointCacheConfiguration,
-                        Cache2kConfig<HBaseMaps.TileKey, Optional<byte[]>> tileCacheConfiguration) throws Exception {
+                        Cache2kConfig<String, Optional<PointFeature.PointFeatures>> pointCacheConfiguration) throws Exception {
       // Either use Zookeeper or static config to locate tables
       Configuration conf = HBaseConfiguration.create();
       conf.set("hbase.zookeeper.quorum", tileServerConfiguration.getHbase().getZookeeperQuorum());
@@ -241,12 +240,12 @@ public class TileServerApplication {
       if (tileServerConfiguration.getMetastore() != null) {
         MapMetastore meta = Metastores.newZookeeperMapsMeta(tileServerConfiguration.getMetastore().getZookeeperQuorum(), 1000,
           tileServerConfiguration.getMetastore().getPath());
-        return new HBaseMaps(conf, meta, tileServerConfiguration.getHbase().getSaltModulusPoints(),tileServerConfiguration.getHbase().getSaltModulusTiles(), cacheManager, meterRegistry, pointCacheConfiguration, tileCacheConfiguration);
+        return new HBaseMaps(conf, meta, tileServerConfiguration.getHbase().getSaltModulusPoints(),tileServerConfiguration.getHbase().getSaltModulusTiles(), cacheManager, meterRegistry, pointCacheConfiguration);
 
       } else {
         Config.HBaseConfiguration hbase = tileServerConfiguration.getHbase();
         MapMetastore meta = Metastores.newStaticMapsMeta(hbase.getPointsTableName(), hbase.getTilesTableName(), hbase.getTaxonomyTilesTableNames());
-        return new HBaseMaps(conf, meta, tileServerConfiguration.getHbase().getSaltModulusPoints(),tileServerConfiguration.getHbase().getSaltModulusTiles(), cacheManager, meterRegistry, pointCacheConfiguration, tileCacheConfiguration);
+        return new HBaseMaps(conf, meta, tileServerConfiguration.getHbase().getSaltModulusPoints(),tileServerConfiguration.getHbase().getSaltModulusTiles(), cacheManager, meterRegistry, pointCacheConfiguration);
       }
     }
 

--- a/vectortile-server/src/main/java/org/gbif/maps/resource/HBaseMaps.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/resource/HBaseMaps.java
@@ -58,11 +58,8 @@ public class HBaseMaps {
   private final ModulusSalt saltPoints;
   private final ModulusSalt saltTiles;
   private final Cache<String, Optional<PointFeature.PointFeatures>> pointCache;
-  private final Cache<TileKey, Optional<byte[]>> tileCache;
-
   public HBaseMaps(Configuration conf, String tableName, int saltModulusPoints, int saltModulusTiles, SpringCache2kCacheManager cacheManager, MeterRegistry meterRegistry,
-                   Cache2kConfig<String, Optional<PointFeature.PointFeatures>> pointCacheConfiguration,
-                   Cache2kConfig<TileKey, Optional<byte[]>> tileCacheConfiguration) throws Exception {
+                   Cache2kConfig<String, Optional<PointFeature.PointFeatures>> pointCacheConfiguration) throws Exception {
     connection = ConnectionFactory.createConnection(conf);
     // Mounted as backbone to enable diagnostics for the single table use.
     Map<String, String> checklists = new HashMap<>() {{ put(BACKBONE_UUID, tableName);}};
@@ -70,18 +67,15 @@ public class HBaseMaps {
     saltPoints = new ModulusSalt(saltModulusPoints);
     saltTiles = new ModulusSalt(saltModulusTiles);
     pointCache = pointCacheBuilder(cacheManager, meterRegistry, pointCacheConfiguration);
-    tileCache = tileCacheBuilder(cacheManager, meterRegistry, tileCacheConfiguration);
   }
 
   public HBaseMaps(Configuration conf, MapMetastore metastore, int saltModulusPoints, int saltModulusTiles, SpringCache2kCacheManager cacheManager, MeterRegistry meterRegistry,
-                   Cache2kConfig<String, Optional<PointFeature.PointFeatures>> pointCacheConfiguration,
-                   Cache2kConfig<TileKey, Optional<byte[]>> tileCacheConfiguration) throws Exception {
+                   Cache2kConfig<String, Optional<PointFeature.PointFeatures>> pointCacheConfiguration) throws Exception {
     connection = ConnectionFactory.createConnection(conf);
     this.metastore = metastore;
     saltPoints = new ModulusSalt(saltModulusPoints);
     saltTiles = new ModulusSalt(saltModulusTiles);
     pointCache = pointCacheBuilder(cacheManager, meterRegistry, pointCacheConfiguration);
-    tileCache = tileCacheBuilder(cacheManager, meterRegistry, tileCacheConfiguration);
   }
 
   private TableName pointTable() throws Exception {
@@ -149,37 +143,6 @@ public class HBaseMaps {
     return cache;
   }
 
-  private Cache<TileKey, Optional<byte[]>> tileCacheBuilder(SpringCache2kCacheManager manager, MeterRegistry meterRegistry, Cache2kConfig<TileKey, Optional<byte[]>> tileCacheConfiguration) {
-    manager.addCaches( b ->
-      tileCacheConfiguration.builder()
-      .manager(manager.getNativeCacheManager())
-      .name("tileCache")
-      .loader(
-        rowCell -> {
-          TableName name = tileTableName(rowCell.rowKey);
-          if (name == null) return Optional.empty();
-          try (Table table = connection.getTable(name)) {
-            String unsalted = rowCell.rowKey + ":" + rowCell.zxy();
-            byte[] saltedKey = saltTiles.salt(unsalted);
-            Get get = new Get(saltedKey);
-            String columnFamily = rowCell.srs.replaceAll(":", "_").toUpperCase();
-            get.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("tile"));
-            Result result = table.get(get);
-            if (result != null) {
-              byte[] encoded = result.getValue(Bytes.toBytes(columnFamily), Bytes.toBytes("tile"));
-              return Optional.ofNullable(encoded);
-            } else {
-              return Optional.empty();
-            }
-          }
-        }
-      ));
-
-    Cache<TileKey, Optional<byte[]>> cache = manager.getNativeCacheManager().getCache("tileCache");
-    ConfigUtils.registerCacheMetrics(cache, meterRegistry);
-    return cache;
-  }
-
   /**
    * Returns the default tile table or the one for the checklist.
    */
@@ -197,30 +160,20 @@ public class HBaseMaps {
    */
   public Optional<byte[]> getTile(String mapKey, String srs, int z, long x, long y) {
     try {
-      return tileCache.get(new TileKey(mapKey, srs, z, x, y));
-    } catch (Exception e) {
-      // there is nothing the caller can do.  Swallow this here, logging the error
-      LOG.error("Unexpected error loading tile data from HBase.  Returning no tile.", e);
-      return Optional.empty();
-    }
-  }
+      TileKey rowCell = new TileKey(mapKey, srs, z, x, y);
 
-  /**
-   * For testing.  Does not cache!
-   * Returns a tile from HBase if one exists.
-   */
-  Optional<byte[]> getTileNoCache(String mapKey, String srs, int z, long x, long y) {
-    Stopwatch timer = new Stopwatch().start();
-    try {
-      try (Table table = connection.getTable(tileTableName(mapKey))) {
-        Get get = new Get(Bytes.toBytes(mapKey));
-        String columnFamily = srs.replaceAll(":", "_").toUpperCase();
-        get.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes(z + ":" + x + ":" + y));
+      TableName name = tileTableName(rowCell.rowKey);
+      if (name == null) return Optional.empty();
+      try (Table table = connection.getTable(name)) {
+        String unsalted = rowCell.rowKey + ":" + rowCell.zxy();
+        byte[] saltedKey = saltTiles.salt(unsalted);
+        Get get = new Get(saltedKey);
+        String columnFamily = rowCell.srs.replaceAll(":", "_").toUpperCase();
+        get.addColumn(Bytes.toBytes(columnFamily), Bytes.toBytes("tile"));
         Result result = table.get(get);
         if (result != null) {
-          byte[] encoded = result.getValue(Bytes.toBytes(columnFamily), Bytes.toBytes(z + ":" + x + ":" + y));
-          LOG.info("HBase lookup of {} returned {}kb and took {}ms", z + ":" + x + ":" + y, encoded.length / 1024, timer.elapsedMillis());
-          return Optional.of(encoded);
+          byte[] encoded = result.getValue(Bytes.toBytes(columnFamily), Bytes.toBytes("tile"));
+          return Optional.ofNullable(encoded);
         } else {
           return Optional.empty();
         }

--- a/vectortile-server/src/main/java/org/gbif/maps/resource/HBaseMaps.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/resource/HBaseMaps.java
@@ -114,11 +114,12 @@ public class HBaseMaps {
       .name("pointCache")
       .loader(
         rowKey -> {
-          LOG.info("Table {}", metastore.read().getPointTable());
+          MapTables mapTables = metastore.read();
+          LOG.debug("Table {}", mapTables.getPointTable());
           TableName name = pointTable();
           if (name == null) return Optional.empty();
           try (Table table = connection.getTable(name)) {
-            LOG.info(saltPoints.saltToString(rowKey));
+            LOG.debug(saltPoints.saltToString(rowKey));
             byte[] saltedKey = saltPoints.salt(rowKey);
             Get get = new Get(saltedKey);
             get.addColumn(Bytes.toBytes("EPSG_4326"), Bytes.toBytes("features"));
@@ -212,7 +213,7 @@ public class HBaseMaps {
    */
   Optional<PointFeature.PointFeatures> getPoints(String mapKey) {
     try {
-      LOG.info("Getting points");
+      LOG.debug("Getting points");
       return pointCache.get(mapKey);
     } catch (Exception e) {
       // there is nothing the caller can do.  Swallow this here, logging the error

--- a/vectortile-server/src/main/java/org/gbif/maps/utils/ExportRawTile.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/utils/ExportRawTile.java
@@ -63,7 +63,7 @@ public class ExportRawTile {
       Configuration conf = HBaseConfiguration.create();
       conf.set("hbase.zookeeper.quorum", zk);
       HBaseMaps maps = null;
-        maps = new HBaseMaps(conf, tableName, saltPoints, saltTiles, new SpringCache2kCacheManager(), new SimpleMeterRegistry(), new Cache2kConfig<>(){}, new Cache2kConfig<>(){});
+        maps = new HBaseMaps(conf, tableName, saltPoints, saltTiles, new SpringCache2kCacheManager(), new SimpleMeterRegistry(), new Cache2kConfig<>(){});
       Optional<byte[]> tile = maps.getTile(mapKey, srs, z, x, y);
       if (tile.isPresent()) {
         Files.write(tile.get(), targetFile);


### PR DESCRIPTION
Removes the tile cache (will need removed in config completely) and removes the unused and incorrect `getTileNoCache` which is a left over from early development.