### PR TITLE
Fix weekly OOM: bound pointCache size and invalidate on HBase table swap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Build all modules
+mvn clean install
+
+# Build and deploy (as used in CI)
+mvn clean verify deploy -B -U
+
+# Build a specific module
+mvn clean install -pl vectortile-server
+
+# Build vectortile-server with environment profile (required for deployment)
+mvn clean package -U -Pvectortile
+
+# Run the vectortile-server
+java -jar vectortile-server/target/vectortile-server-*-SNAPSHOT.jar
+
+# Run all tests
+mvn test
+
+# Run a single test class
+mvn test -pl common -Dtest=VectorTileFiltersTest
+
+# Run a single test method
+mvn test -pl common -Dtest=VectorTileFiltersTest#testMethod
+
+# Integration tests (named *IT.java) run via failsafe, not surefire
+mvn verify -pl vectortile-server
+```
+
+## Module Structure
+
+This is a Maven multi-module project. The modules and their roles:
+
+- **`common`** — Shared library: tile projections (EPSG), vector tile filtering, HBase row key salting, ZooKeeper metastore client, hex/square binning. Contains the two Protobuf schemas (`point_feature.proto`, `tile_feature.proto`) for HBase storage.
+- **`vectortile-common`** — Shared Spring/REST code reused by both tile servers: `Config.java` (HBase + ES config POJOs), `AdHocMapsResource` base class, `Params` utilities, OpenAPI annotations.
+- **`vectortile-server`** — Spring Boot server serving occurrence density maps. Two data sources: HBase (pre-built "simple maps") and ElasticSearch (ad hoc queries). Entry point: `TileServerApplication`.
+- **`event-vectortile-server`** — Spring Boot server for event-based maps. Mirrors the occurrence server structure; uses `AdHocEventMapsResource` instead.
+- **`spark-generate-maps`** — Spark batch job that reads from Hive (`occurrence` table) and builds HBase tile pyramids. Main entry points: `Backfill` (called from Airflow with `configFile timestamp` args), `PrepareBackfill`, `FinaliseBackfill`.
+- **`mapnik-server`** — Docker-based PNG renderer: accepts vector tiles and renders them via Mapnik. Built with Maven, run via Docker.
+
+## Architecture
+
+### Two map types
+1. **Simple maps** (high-performance): Pre-built by the Spark job from the full occurrence dataset. Stored in HBase as Protobuf-encoded tile pyramids, keyed by map type (taxonKey, datasetKey, country, etc.). Filterable only by `basisOfRecord` and `year` at serve time.
+2. **Ad hoc maps** (full-search): Live ElasticSearch geohash aggregation queries. Supports the full occurrence search API filters. Significantly slower.
+
+### URL patterns (context path `/map/`)
+- Simple: `GET /occurrence/density/{z}/{x}/{y}.mvt?taxonKey=212`
+- Ad hoc: `GET /occurrence/density/adhoc/{z}/{x}/{y}.mvt?taxonKey=212&hasGeospatialIssue=true`
+
+### HBase storage
+- Two table types: **points table** (raw `PointFeatures` protobuf, individual occurrences) and **tiles table** (pre-aggregated `TileFeatures` protobuf, pixel-precision counts per BasisOfRecord/year).
+- Row keys are salted with a modulus hash (`ModulusSalt`) to distribute load. Salt moduli for points and tiles are configured separately and must match between the Spark build and the tile server.
+- The `MapMetastore` interface (backed by ZooKeeper) stores which HBase table names are currently active, enabling hot-swapping tables during backfills without downtime.
+
+### Supported projections
+Four EPSG codes are supported (factory: `Tiles.fromEPSG`):
+- `EPSG:3857` — Web Mercator (default web maps)
+- `EPSG:4326` — WGS84 (two-tile world)
+- `EPSG:3575` — North Pole Lambert Azimuthal Equal Area
+- `EPSG:3031` — Antarctic Polar Stereographic
+
+### Protobuf
+Protobuf schemas live in `common/src/main/proto/`. The protoc version must match `<protoc.version>` in the root `pom.xml` (currently 4.33.4). See the root `README.md` for installation steps. Generated Java sources are in `common/src/main/java/org/gbif/maps/io/`.
+
+### Spark backfill workflow
+`MapBuilder` (called by `Backfill`) reads from a Hive view, runs UDFs to compute tile coordinates and HBase row keys, then writes HBase bulk-load files. Mode is either `tiles` or `points`. `FinaliseBackfill` triggers a ZooKeeper metastore update to point the tile servers at the new tables.
+
+## Key Design Decisions
+
+- **Salt modulus** values in HBase config must stay in sync between Spark (write) and vectortile-server (read). Changing them requires a full backfill.
+- **`esOccurrenceConfiguration.enabled`** flag gates all ElasticSearch beans and the ad hoc endpoint. The `es-only` Spring profile disables the HBase bean entirely.
+- **Cache2k** is used for in-process tile and point caching in `HBaseMaps`. Cache configuration is injected as `Cache2kConfig` beans.
+- The Spark SQL query in `MapBuilder.SQL_TEXT` always filters `hasGeospatialIssues = false` and `occurrenceStatus = 'PRESENT'`; simple maps therefore never include records with geospatial issues.

--- a/common/src/main/java/org/gbif/maps/common/meta/MapMetastore.java
+++ b/common/src/main/java/org/gbif/maps/common/meta/MapMetastore.java
@@ -33,4 +33,11 @@ public interface MapMetastore extends Closeable {
    * @param meta To create or replace existing values.
    */
   void update(MapTables meta) throws Exception;
+
+  /**
+   * Registers a listener that is called whenever the underlying table metadata changes.
+   * Implementations backed by static data may ignore this.
+   */
+  default void registerChangeListener(Runnable listener) {
+  }
 }

--- a/common/src/main/java/org/gbif/maps/common/meta/ZKMapMetastore.java
+++ b/common/src/main/java/org/gbif/maps/common/meta/ZKMapMetastore.java
@@ -15,6 +15,8 @@ package org.gbif.maps.common.meta;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import javax.annotation.Nullable;
 
@@ -42,6 +44,7 @@ class ZKMapMetastore implements MapMetastore, Closeable {
   private final NodeCache zkNodeCache;
   private final String zkNodePath;
   private MapTables mapTables;
+  private final List<Runnable> changeListeners = new CopyOnWriteArrayList<>();
 
   ZKMapMetastore(String zkEnsemble, int retryIntervalMs, String zkNodePath) throws Exception {
     this.zkNodePath = zkNodePath;
@@ -81,6 +84,11 @@ class ZKMapMetastore implements MapMetastore, Closeable {
   }
 
   @Override
+  public void registerChangeListener(Runnable listener) {
+    changeListeners.add(listener);
+  }
+
+  @Override
   public void close() throws IOException {
     Closeables.close(zkNodeCache, true);
     Closeables.close(client, true);
@@ -95,6 +103,7 @@ class ZKMapMetastore implements MapMetastore, Closeable {
       ChildData child = cache.getCurrentData();
       mapTables = MapTables.deserialize(child.getData());
       LOG.info("MapTables for {} updated {}", zkNodePath, mapTables);
+      changeListeners.forEach(Runnable::run);
     } catch(Exception e) {
       LOG.error("Unable to update MapTables from ZooKeeper (MapMeta may return state data until recovered).", e);
     }

--- a/vectortile-server/src/main/java/org/gbif/maps/resource/HBaseMaps.java
+++ b/vectortile-server/src/main/java/org/gbif/maps/resource/HBaseMaps.java
@@ -67,6 +67,7 @@ public class HBaseMaps {
     saltPoints = new ModulusSalt(saltModulusPoints);
     saltTiles = new ModulusSalt(saltModulusTiles);
     pointCache = pointCacheBuilder(cacheManager, meterRegistry, pointCacheConfiguration);
+    metastore.registerChangeListener(pointCache::clear);
   }
 
   public HBaseMaps(Configuration conf, MapMetastore metastore, int saltModulusPoints, int saltModulusTiles, SpringCache2kCacheManager cacheManager, MeterRegistry meterRegistry,
@@ -76,6 +77,7 @@ public class HBaseMaps {
     saltPoints = new ModulusSalt(saltModulusPoints);
     saltTiles = new ModulusSalt(saltModulusTiles);
     pointCache = pointCacheBuilder(cacheManager, meterRegistry, pointCacheConfiguration);
+    metastore.registerChangeListener(pointCache::clear);
   }
 
   private TableName pointTable() throws Exception {

--- a/vectortile-server/src/main/resources/application.yml
+++ b/vectortile-server/src/main/resources/application.yml
@@ -33,8 +33,9 @@ server:
     excluded-user-agents:
 cache:
   points:
-    entryCapacity: 200      # tune relative to -Xmx; each entry can be tens of MB for large taxa
-    expireAfterWrite: PT25H # force reload after the weekly Spark backfill (25 h > 1 day, < 1 week)
+    entryCapacity: 1_000
+    permitNullValues: true
+    expireAfterWrite: PT10M
 
 spring:
   config:

--- a/vectortile-server/src/main/resources/application.yml
+++ b/vectortile-server/src/main/resources/application.yml
@@ -31,6 +31,11 @@ server:
     min-response-size: 1
     mime-types: application/json,application/xml,text/html,text/xml,text/plain,application/javascript,text/css,image/jpeg,application/x-protobuf,application/gzip
     excluded-user-agents:
+cache:
+  points:
+    entryCapacity: 200      # tune relative to -Xmx; each entry can be tens of MB for large taxa
+    expireAfterWrite: PT25H # force reload after the weekly Spark backfill (25 h > 1 day, < 1 week)
+
 spring:
   config:
     import: "optional:zookeeper:"


### PR DESCRIPTION
## Root cause

The `pointCache` in `HBaseMaps` stored `PointFeature.PointFeatures` protobuf objects with Cache2k's default `eternal = true` policy and no entry-count or memory limit. Because the `cache.points.*` block was missing entirely from `application.yml`, up to 2000 entries accumulated indefinitely. Each entry can be 10–20 MB of deserialized Java objects for taxa with many occurrences (74 K features observed at crash time), giving a cache footprint of 20–40 GB — matching the 20 GB heap dump from the weekly OOM.

After each weekly Spark backfill, the ZooKeeper metastore swapped to new HBase tables but the point cache was never cleared, so stale entries from the old table persisted across generations while the cache refilled with entries from the new table.

A secondary amplifier: `VectorTileFilters` has intermediate batch-flushing disabled (Issue #99 hotfix), so every tile request accumulates all features in a `HashMap` before writing to the encoder. With 200 concurrent threads (observed at crash time), this adds several GB of transient heap pressure on top of the full cache.

## Changes

### `application.yml`
Adds the missing `cache.points` block:
- `entryCapacity: 200` — hard cap on the number of large protobuf objects held; tune relative to `-Xmx` (rule of thumb: `entryCapacity = Xmx_bytes × 0.25 / avg_entry_bytes`)
- `expireAfterWrite: PT25H` — forces reload within 25 h of load time, ensuring entries self-invalidate well within a week regardless of table swaps

### `MapMetastore`
Adds a `default void registerChangeListener(Runnable)` hook so callers can react to table-name changes. The default no-op keeps all existing implementations (static metastore) unchanged.

### `ZKMapMetastore`
Implements the listener list using `CopyOnWriteArrayList` and fires all listeners inside `updateInternal()` after ZooKeeper notifies of a node change. This means `FinaliseBackfill`'s ZK write immediately triggers cache eviction on the tile server.

### `HBaseMaps`
Both constructors now call `metastore.registerChangeListener(pointCache::clear)` after building the cache, wiring up immediate invalidation on table swap.

### `CLAUDE.md`
Adds build commands, module descriptions, architecture overview and key design decisions to help future contributors (and AI assistants) navigate the codebase.

## Test plan

- [ ] Verify `mvn compile` passes (protoc errors are pre-existing; generated sources are committed)
- [ ] Deploy to staging with `cache.points.entryCapacity: 200` and monitor `cache.size` / `cache.evictions` via Micrometer (`/actuator/metrics/cache.size?tag=cache:pointCache`)
- [ ] Confirm heap stays stable (< 70% of `-Xmx`) under normal traffic across a full week
- [ ] Trigger a test backfill and verify `pointCache` is cleared immediately (log line: `MapTables for … updated …` followed by cache eviction metrics resetting to 0)
- [ ] Confirm no OOM after the next production weekly Spark backfill

## Remaining issues (follow-up)

- **Issue #99**: intermediate batch flush in `VectorTileFilters` is still disabled — needs a proper fix to avoid duplicate pixel emissions without accumulating all features in RAM
- **`capabilities()` double load**: the endpoint calls `getTile(z=0)` twice per request, processing point features twice; consider caching the capabilities response or computing it directly from `PointFeatures`

🤖 Generated with [Claude Code](https://claude.com/claude-code)